### PR TITLE
Patch Notes

### DIFF
--- a/src/pages/idtga/index.js
+++ b/src/pages/idtga/index.js
@@ -33,26 +33,23 @@ const Idtga = () => (
         <table class="table">
           <tbody>
             <ScheduleTime date="4 Days">
-              Check-in opens and registration remains <strong>open</strong>.
+              Check-in opens and registration <strong>remains open</strong>.
             </ScheduleTime>
             <ScheduleTime date="3 Days">
-              Check-in and registration will close, invalid attendees will be
-              removed, and team creation will start.
+              Both check-in and registration will close, invalid attendees will
+              be removed, and we start assembling teams.
             </ScheduleTime>
             <ScheduleTime date="2 Days">
-              Players will receive their teams
-            </ScheduleTime>
-    	 	<ScheduleTime date="24 Hours">
-              The maplist will be published
+              Players receive their teams, and the maplist is published. You can
+              now practice with your team.
             </ScheduleTime>
             <ScheduleTime date="1 Hour">
-              Players will be alerted and preparations will commence.
-            </ScheduleTime>
-            <ScheduleTime date="30 Minutes">
-              Players are requested to be online on both Splatoon 2 and Discord.
+              Players will be alerted and preparations will commence. We request
+              that you be online on both Splatoon 2 and Discord.
             </ScheduleTime>
             <ScheduleTime date="10 Minutes">
-              Stream begins on <Link to="/twitch">twitch</Link>.
+              Stream begins on <Link to="/twitch">twitch</Link>, check it out if
+              you're not playing!
             </ScheduleTime>
           </tbody>
         </table>

--- a/src/pages/idtga/index.js
+++ b/src/pages/idtga/index.js
@@ -32,15 +32,18 @@ const Idtga = () => (
         <h2>Schedule</h2>
         <table class="table">
           <tbody>
-            <ScheduleTime date="3 Days">
+            <ScheduleTime date="4 Days">
               Check-in opens and registration remains <strong>open</strong>.
             </ScheduleTime>
-            <ScheduleTime date="2 Days">
+            <ScheduleTime date="3 Days">
               Check-in and registration will close, invalid attendees will be
               removed, and team creation will start.
             </ScheduleTime>
-            <ScheduleTime date="24 Hours">
-              Players will receive their teams, and maplist is released.
+            <ScheduleTime date="2 Days">
+              Players will receive their teams
+            </ScheduleTime>
+    	 	<ScheduleTime date="24 Hours">
+              The maplist will be published
             </ScheduleTime>
             <ScheduleTime date="1 Hour">
               Players will be alerted and preparations will commence.

--- a/src/pages/idtga/rules.md
+++ b/src/pages/idtga/rules.md
@@ -45,31 +45,22 @@ In the case of a dropout, an emergency sub may be needed.
 - Must be approved by a TO.
 - Players can apply to be an emergency sub before the tournament by sending a dm to <Mention>@DJam98</Mention>.
 
-## Disconnections (DCs)
-There are two types of DCs - *Early DCs* and *Game DCs*. Each team is has a quota of one *Ealy DC* and one *Game DC* per match.
-
-### Early DCs
-- An *Early DC* is when a DC occurs anytime before the the game actually starts (when the in-game timer starts ticking down). This includes the lobby screen and the flyover at the start of the game.
-- Each team is allowed one *Early DC* per match.
-
-### Game DCs
-- A *Game DC* is a DC that occurs during the actual game.
-- A *Game DC* can only occur if the following circumstances are met;
-
-#### Redo the match if:
+## DC's Redo Decision Rules
+### Redo the match if:
 - The team with the DC stops playing and allows the other team to KO.
 - The team with the DC stays inside their spawn barrier.
-- Both teams use the same weapons and gear
+- The team with the DC uses the same weapons/gear shown in the results.
 
 ### Do NOT redo the match if:
 - **Any player** on the same team DC's again in the same round.
+- The same player DC's again **any other time** in the tournament.
 - The host DC's.
 - The match has passed 2:30 before the DC'ing team has forfeited.
 - The team without a DC has 50 or less objective remaining (excluding penalty).
 
-If either 2 DC’s occur in the same lobby or the host DC’s, the team currently not hosting must host a new lobby. If this occurs again when the other team is hosting, players may request a staff member to host the game.
+If either 2 DC’s occur in the same lobby or the host DC’s, the team currently not hosting must host a new lobby.
 
-To reduce the chances of a DC happening, please check you have a good internet connection with low ping and/or have a LAN adapter for a smoother experience. If not, consider switching hosts.
+To reduce the chances of a dc happening, please check you have a good internet connection with low ping and/or have a LAN adapter for a smoother experience. If not, consider switching hosts.
 
 If there's are complaints about lag from at least 3 people on the same team or 1 person from each team, teams are required to switch hosts to someone on the opposing team.
 

--- a/src/pages/idtga/rules.md
+++ b/src/pages/idtga/rules.md
@@ -45,22 +45,31 @@ In the case of a dropout, an emergency sub may be needed.
 - Must be approved by a TO.
 - Players can apply to be an emergency sub before the tournament by sending a dm to <Mention>@DJam98</Mention>.
 
-## DC's Redo Decision Rules
-### Redo the match if:
+## Disconnections (DCs)
+There are two types of DCs - *Early DCs* and *Game DCs*. Each team is has a quota of one *Ealy DC* and one *Game DC* per match.
+
+### Early DCs
+- An *Early DC* is when a DC occurs anytime before the the game actually starts (when the in-game timer starts ticking down). This includes the lobby screen and the flyover at the start of the game.
+- Each team is allowed one *Early DC* per match.
+
+### Game DCs
+- A *Game DC* is a DC that occurs during the actual game.
+- A *Game DC* can only occur if the following circumstances are met;
+
+#### Redo the match if:
 - The team with the DC stops playing and allows the other team to KO.
 - The team with the DC stays inside their spawn barrier.
-- The team with the DC uses the same weapons/gear shown in the results.
+- Both teams use the same weapons and gear
 
 ### Do NOT redo the match if:
 - **Any player** on the same team DC's again in the same round.
-- The same player DC's again **any other time** in the tournament.
 - The host DC's.
 - The match has passed 2:30 before the DC'ing team has forfeited.
 - The team without a DC has 50 or less objective remaining (excluding penalty).
 
-If either 2 DC’s occur in the same lobby or the host DC’s, the team currently not hosting must host a new lobby.
+If either 2 DC’s occur in the same lobby or the host DC’s, the team currently not hosting must host a new lobby. If this occurs again when the other team is hosting, players may request a staff member to host the game.
 
-To reduce the chances of a dc happening, please check you have a good internet connection with low ping and/or have a LAN adapter for a smoother experience. If not, consider switching hosts.
+To reduce the chances of a DC happening, please check you have a good internet connection with low ping and/or have a LAN adapter for a smoother experience. If not, consider switching hosts.
 
 If there's are complaints about lag from at least 3 people on the same team or 1 person from each team, teams are required to switch hosts to someone on the opposing team.
 

--- a/src/pages/wl/index.js
+++ b/src/pages/wl/index.js
@@ -71,23 +71,23 @@ const WeakestLink = () => (
         <table class="table">
           <tbody>
             <ScheduleTime date="9 Days">
-              Check-in opens and registration remains <strong>open</strong>.
+              Check-in opens and registration <strong>remains open</strong>.
             </ScheduleTime>
             <ScheduleTime date="8 Days">
-              Check-in and registration will close, invalid attendees will be
-              removed, and team creation will start.
+              Both check-in and registration will close, invalid attendees will
+              be removed, and we start assembling teams.
             </ScheduleTime>
             <ScheduleTime date="7 Days">
-              Players will receive their teams, and maplist is released.
+              Players receive their teams, and the maplist is published. You can
+              now practice with your team.
             </ScheduleTime>
             <ScheduleTime date="1 Hour">
-              Players will be alerted and preparations will commence.
-            </ScheduleTime>
-            <ScheduleTime date="30 Minutes">
-              Players are requested to be online on both Splatoon 2 and Discord.
+              Players will be alerted and preparations will commence. We request
+              that you be online on both Splatoon 2 and Discord.
             </ScheduleTime>
             <ScheduleTime date="10 Minutes">
-              Stream begins on <Link to="/twitch">twitch</Link>.
+              Stream begins on <Link to="/twitch">twitch</Link>, check it out if
+              you're not playing!
             </ScheduleTime>
           </tbody>
         </table>

--- a/src/pages/wl/rules.md
+++ b/src/pages/wl/rules.md
@@ -48,22 +48,31 @@ If your team is consistently acting disrespectful towards you, you can request 1
 
 If a team has requested to replace you, you will be removed from the tournament and marked as a dropout (See **[Dropouts](#dropouts)**).
 
-## DC's Redo Decision Rules
-### Redo the match if:
+## Disconnections (DCs)
+There are two types of DCs - *Early DCs* and *Game DCs*. Each team is has a quota of one *Ealy DC* and one *Game DC* per match.
+
+### Early DCs
+- An *Early DC* is when a DC occurs anytime before the the game actually starts (when the in-game timer starts ticking down). This includes the lobby screen and the flyover at the start of the game.
+- Each team is allowed one *Early DC* per match.
+
+### Game DCs
+- A *Game DC* is a DC that occurs during the actual game.
+- A *Game DC* can only occur if the following circumstances are met;
+
+#### Redo the match if:
 - The team with the DC stops playing and allows the other team to KO.
 - The team with the DC stays inside their spawn barrier.
-- The team with the DC uses the same weapons/gear shown in the results screen.
+- Both teams use the same weapons and gear
 
 ### Do NOT redo the match if:
 - **Any player** on the same team DC's again in the same round.
-- The same player DC's again **any other time** in the tournament.
 - The host DC's.
 - The match has passed 2:30 before the DC'ing team has forfeited.
 - The team without a DC has 50 or less objective remaining (excluding penalty).
 
-If either 2 DC’s occur in the same lobby or the host DC’s, the team currently not hosting must host a new lobby.
+If either 2 DC’s occur in the same lobby or the host DC’s, the team currently not hosting must host a new lobby. If this occurs again when the other team is hosting, players may request a staff member to host the game.
 
-To reduce the chances of a dc happening, please check you have a good internet connection with low ping and/or have a LAN adapter for a smoother experience. If not, consider switching hosts.
+To reduce the chances of a DC happening, please check you have a good internet connection with low ping and/or have a LAN adapter for a smoother experience. If not, consider switching hosts.
 
 If there's are complaints about lag from at least 3 people on the same team or 1 person from each team, teams are required to switch hosts to someone on the opposing team.
 

--- a/src/pages/wl/rules.md
+++ b/src/pages/wl/rules.md
@@ -48,31 +48,23 @@ If your team is consistently acting disrespectful towards you, you can request 1
 
 If a team has requested to replace you, you will be removed from the tournament and marked as a dropout (See **[Dropouts](#dropouts)**).
 
-## Disconnections (DCs)
-There are two types of DCs - *Early DCs* and *Game DCs*. Each team is has a quota of one *Ealy DC* and one *Game DC* per match.
 
-### Early DCs
-- An *Early DC* is when a DC occurs anytime before the the game actually starts (when the in-game timer starts ticking down). This includes the lobby screen and the flyover at the start of the game.
-- Each team is allowed one *Early DC* per match.
-
-### Game DCs
-- A *Game DC* is a DC that occurs during the actual game.
-- A *Game DC* can only occur if the following circumstances are met;
-
-#### Redo the match if:
+## DC's Redo Decision Rules
+### Redo the match if:
 - The team with the DC stops playing and allows the other team to KO.
 - The team with the DC stays inside their spawn barrier.
-- Both teams use the same weapons and gear
+- The team with the DC uses the same weapons/gear shown in the results screen.
 
 ### Do NOT redo the match if:
 - **Any player** on the same team DC's again in the same round.
+- The same player DC's again **any other time** in the tournament.
 - The host DC's.
 - The match has passed 2:30 before the DC'ing team has forfeited.
 - The team without a DC has 50 or less objective remaining (excluding penalty).
 
-If either 2 DC’s occur in the same lobby or the host DC’s, the team currently not hosting must host a new lobby. If this occurs again when the other team is hosting, players may request a staff member to host the game.
+If either 2 DC’s occur in the same lobby or the host DC’s, the team currently not hosting must host a new lobby.
 
-To reduce the chances of a DC happening, please check you have a good internet connection with low ping and/or have a LAN adapter for a smoother experience. If not, consider switching hosts.
+To reduce the chances of a dc happening, please check you have a good internet connection with low ping and/or have a LAN adapter for a smoother experience. If not, consider switching hosts.
 
 If there's are complaints about lag from at least 3 people on the same team or 1 person from each team, teams are required to switch hosts to someone on the opposing team.
 


### PR DESCRIPTION
Players will recieve their teams 2 days before the tournament. This is so that teams that have players on an international scale are able to organise practice sessions.

Disconnect rules have been altered to add Early DCs and remove the player dc rule across the whole tournament (since that is extremly hard to track).